### PR TITLE
formの生成例のnameをform_nameにする

### DIFF
--- a/schema/paths/forms/index.yml
+++ b/schema/paths/forms/index.yml
@@ -21,7 +21,7 @@ post:
         examples:
           form:
             value:
-              name: お問い合わせフォーム
+              form_name: お問い合わせフォーム
               questions:
                 - title: 名前
                   description: 名前を入力してください

--- a/schema/paths/forms/index.yml
+++ b/schema/paths/forms/index.yml
@@ -16,7 +16,7 @@ post:
                   items:
                     $ref: './types/question.yml#/schemas/question_dynamic_props'
           required:
-            - name
+            - form_name
             - questions
         examples:
           form:
@@ -90,7 +90,7 @@ get:
                 - $ref: './types/form.yml#/schemas/form_dynamic_props'
               required:
                 - id
-                - name
+                - form_name
                 - description
     '401':
       description: 認証がされていない

--- a/schema/paths/forms/types/form.yml
+++ b/schema/paths/forms/types/form.yml
@@ -30,5 +30,5 @@ schemas:
             $ref: './question.yml#/schemas/questions'
     required:
       - id
-      - name
+      - form_name
       - questions

--- a/schema/paths/forms/types/form.yml
+++ b/schema/paths/forms/types/form.yml
@@ -8,7 +8,7 @@ schemas:
   form_dynamic_props:
     type: object
     properties:
-      name:
+      form_name:
         type: string
         example: お問い合わせフォーム
       description:


### PR DESCRIPTION
バックエンド側で要求するものが`name`ではなく`form_name`になったのでapi-schemaもそれに合わせる