### PR TITLE
fix: パスのスキーマを自分で持つ

### DIFF
--- a/schema/paths/forms/types/form.yml
+++ b/schema/paths/forms/types/form.yml
@@ -66,4 +66,8 @@ components:
       name: formId
       required: true
       schema:
-        $ref: '#/components/schemas/form_id'
+        description: フォームのID
+        type: integer
+        format: int64
+        minimum: 0
+        example: 0


### PR DESCRIPTION
refを使っているとなぜかフロントエンド側でエラーになる